### PR TITLE
Size warning fragment

### DIFF
--- a/code/app/src/main/res/layout/size_limit_exceeded.xml
+++ b/code/app/src/main/res/layout/size_limit_exceeded.xml
@@ -1,0 +1,75 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent"
+    android:gravity="center">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.5">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/rounded_popup"
+            android:padding="24dp">
+
+            <!-- Title -->
+            <TextView
+                android:id="@+id/size_exceeded_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="start"
+                android:text="@string/image_size_exceeded_title"
+                android:textColor="@color/black"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!-- Description -->
+            <TextView
+                android:id="@+id/error_message"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:text="@string/image_size_exceeded_message"
+                android:textColor="@color/black"
+                android:textSize="16sp"
+                android:maxWidth="250dp"
+                android:gravity="start"
+                app:layout_constraintStart_toStartOf="@id/size_exceeded_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/size_exceeded_title" />
+
+            <!-- OK Button -->
+            <Button
+                android:id="@+id/ok_button"
+                style="?android:attr/buttonBarButtonStyle"
+                android:clickable="true"
+                android:focusable="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="8dp"
+                android:background="@android:color/transparent"
+                android:padding="8dp"
+                android:gravity="end"
+                android:text="@string/ok_button_text"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintTop_toBottomOf="@id/error_message"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="confirm_button_text">Confirm</string>
     <string name="deny_button_text">Deny</string>
     <string name="allow_button_text">Allow</string>
+    <string name="ok_button_text">OK</string>
 
     <!-- Content Descriptions -->
     <string name="content_desc_tool_icon">Tool Icon</string>
@@ -35,5 +36,9 @@
     <string name="content_desc_perfect_icon">Confirm selection</string>
     <string name="content_desc_back_icon">Back</string>
     <string name="content_desc_edit_profile_icon">Edit Profile</string>
+
+    <!-- Error Messages -->
+    <string name="image_size_exceeded_title">Image size exceed limit</string>
+    <string name="image_size_exceeded_message">Image must be under 65536 bytes</string>
 
 </resources>


### PR DESCRIPTION
- updated string.xml for text consistency
- created error warning fragment when uploading an image to large

<img width="179" alt="Screenshot 2025-02-26 at 4 30 12 PM" src="https://github.com/user-attachments/assets/a493727d-9b53-4b51-8cfe-44056f3e71dc" />
