### PR TITLE
If title is left empty, set to 'Untitled' by default

### DIFF
--- a/code/app/src/main/java/com/example/superior_intelligence/MoodCreateAndEditActivity.java
+++ b/code/app/src/main/java/com/example/superior_intelligence/MoodCreateAndEditActivity.java
@@ -158,6 +158,9 @@ public class MoodCreateAndEditActivity extends AppCompatActivity {
      */
     Event createNewEvent() {
         String eventTitle = headerTitle.getText().toString().trim();
+        if (eventTitle.isEmpty()) {
+            eventTitle = "Untitled"; // Default title
+        }
         String eventDate = new SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault()).format(new Date());
         String overlayColor = getOverlayColorForMood(selectedMood.getText().toString()); // Dynamic based on mood
         int emojiResource = includeEmojiCheckbox.isChecked() ? updateEmojiIcon(selectedMood.getText().toString()) : 0;


### PR DESCRIPTION
While the user isn't made to input a title for a new mood event, if they choose to leave it blank, the title is set to "Untitled" by default upon posting.