### PR TITLE
add filter by recentweek for mypost

### DIFF
--- a/code/app/src/main/java/com/example/superior_intelligence/HomeActivity.java
+++ b/code/app/src/main/java/com/example/superior_intelligence/HomeActivity.java
@@ -186,10 +186,12 @@ public class HomeActivity extends AppCompatActivity {
                         break;
 
                     case "Show posts from last 7 days":
-                        try {
-                            recentWeek(myPostsEvents);
-                        } catch (ParseException e) {
-                            throw new RuntimeException(e);
+                        if ("myposts".equals(currentTab)) {
+                            try {
+                                recentWeek(myPostsEvents);
+                            } catch (ParseException e) {
+                                throw new RuntimeException(e);
+                            }
                         }
                         break;
 


### PR DESCRIPTION
originally filtering by recent week will only work for myPosts regardless of which tab user is on, now change to only when the user is on myposts tab