### PR TITLE
Bug shouldn't be able to send multiple follow requests to same user

### DIFF
--- a/code/app/src/main/java/com/example/superior_intelligence/Userbase.java
+++ b/code/app/src/main/java/com/example/superior_intelligence/Userbase.java
@@ -328,3 +328,4 @@ public class Userbase {
         void onUserListRetrieved(List<String> users);
     }
 }
+

--- a/code/app/src/main/java/com/example/superior_intelligence/Userbase.java
+++ b/code/app/src/main/java/com/example/superior_intelligence/Userbase.java
@@ -126,22 +126,31 @@ public class Userbase {
     }
 
     public void sendFollowRequest(String requester, String requested, FollowRequestActionCallback callback) {
-        Log.d("FollowDebug", " Sending follow request: " + requester + " -> " + requested);
-        HashMap<String, Object> requestData = new HashMap<>();
-        requestData.put("requester", requester);
-        requestData.put("requested", requested);
-        requestData.put("timestamp", System.currentTimeMillis());
+        Log.d("FollowDebug", "Attempting to send follow request: " + requester + " -> " + requested);
 
-        db.collection("follow_requests")
-                .add(requestData)
-                .addOnSuccessListener(documentReference -> {
-                    Log.d("FollowDebug", "Follow request sent from " + requester + " to " + requested);
-                    callback.onFollowRequestAction(true);
-                })
-                .addOnFailureListener(e -> {
-                    Log.e("FollowDebug", "Failed to send follow request.", e);
-                    callback.onFollowRequestAction(false);
-                });
+        // First, check if a request already exists
+        checkFollowRequest(requester, requested, exists -> {
+            if (exists) {
+                Log.d("FollowDebug", "Follow request already exists, skipping duplicate.");
+                callback.onFollowRequestAction(false); // Or provide a separate status for "already exists"
+            } else {
+                HashMap<String, Object> requestData = new HashMap<>();
+                requestData.put("requester", requester);
+                requestData.put("requested", requested);
+                requestData.put("timestamp", System.currentTimeMillis());
+
+                db.collection("follow_requests")
+                        .add(requestData)
+                        .addOnSuccessListener(documentReference -> {
+                            Log.d("FollowDebug", "Follow request sent from " + requester + " to " + requested);
+                            callback.onFollowRequestAction(true);
+                        })
+                        .addOnFailureListener(e -> {
+                            Log.e("FollowDebug", "Failed to send follow request.", e);
+                            callback.onFollowRequestAction(false);
+                        });
+            }
+        });
     }
 
     public void getIncomingFollowRequests(String username, FollowRequestListCallback callback) {

--- a/code/app/src/test/java/com/example/superior_intelligence/NotificationActivityTest.java
+++ b/code/app/src/test/java/com/example/superior_intelligence/NotificationActivityTest.java
@@ -1,0 +1,49 @@
+package com.example.superior_intelligence;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import android.content.Intent;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+@RunWith(AndroidJUnit4.class)
+public class NotificationActivityTest {
+
+    @Test
+    public void testFetchIncomingRequests_populatesRecyclerView() {
+        // Arrange
+        Userbase mockUserbase = mock(Userbase.class);
+        User mockUser = mock(User.class);
+        when(mockUser.getUsername()).thenReturn("testuser");
+
+        doAnswer(invocation -> {
+            Userbase.FollowRequestListCallback callback = invocation.getArgument(1);
+            callback.onFollowRequestsFetched(Arrays.asList("alice", "bob"));
+            return null;
+        }).when(mockUserbase).getIncomingFollowRequests(eq("testuser"), any());
+
+        // Launch activity
+        ActivityScenario<NotificationActivity> scenario = ActivityScenario.launch(NotificationActivity.class);
+
+        scenario.onActivity(activity -> {
+            // Inject mocks
+            activity.setUser(mockUser);
+            activity.setUserbase(mockUserbase);
+
+            // Act
+            activity.fetchIncomingRequests();
+
+            // Assert
+            RecyclerView recycler = activity.findViewById(R.id.notifications_recycler_view);
+            assertNotNull(recycler.getAdapter());
+            assertEquals(2, recycler.getAdapter().getItemCount());
+        });
+    }
+}


### PR DESCRIPTION
There was a bug where the same user could be sent multiple follow requests while the first one was still pending. The ideal behaviour is that once a follow request has been sent, no new follow requests can be sent to the same user until they decline the existing follow request. This has been implemented now. 